### PR TITLE
docs(vscode plugin): Add VSCode plugin.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,12 @@
   yarn add @inloco/atomic-bomb
 ```
 
-### Release
+We highly recommend this VS Code plugin. It auto-completes `atomic-bomb` css rules.
+
+[IntelliSense for CSS class names in HTML](https://marketplace.visualstudio.com/items?itemName=Zignd.html-css-class-completion)
+
+
+## Release
 
 To release, follow these steps (let's pretend we're releasing `1.2.3`):
 


### PR DESCRIPTION
Encontrei um plugin irado que auto completa as classes do atomic-bomb.

![2019-05-25 15 40 55](https://user-images.githubusercontent.com/1139664/58373392-f72c0f00-7f03-11e9-95d1-60744fa76992.gif)
