### PR TITLE
chore(noCache): Disable parcel's cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "tailwindcss": "^1.0.1"
   },
   "scripts": {
-    "build": "parcel build atomic-bomb.js",
+    "build": "parcel build atomic-bomb.js --no-cache",
     "prepublishOnly": "npm run build"
   },
   "prettier": {


### PR DESCRIPTION
This was not working well with Tailwind, and the build is fast enough without a cache, specially since we only build it when publishing.