### PR TITLE
refactor(circleci): Remove context. Asked by Dev Ops team

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,6 @@ workflows:
       - deploy:
           requires:
             - build
-          context: app-atomic-bomb
           filters:
             branches:
               only: master


### PR DESCRIPTION
O pessoal pediu pra tirar o `context`, já que setou este usuário `app-atomic-bomb` como usuário default.