### PR TITLE
feature(radius): Add border radius 0

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -152,6 +152,7 @@ module.exports = {
       magenta: _.pick(theme('colors.magenta'), ['500'])
     }),
     borderRadius: {
+      none: '0',
       default: '4px',
       full: '9999px'
     },


### PR DESCRIPTION
It's useful for setting border radius partially, for example: `rounded rounded-r-none`, to get an element with rounded borders only on the left side.